### PR TITLE
fix: grade columns in deterministic ordering

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::Write;
 /// This module contains functions for parsing CSV files containing course information.
@@ -40,7 +40,7 @@ struct CourseInfo {
     course_number: String,
     course_title: String,
     course_full_title: String,
-    grade: HashMap<String, u16>,
+    grade: BTreeMap<String, u16>,
 }
 
 /// Represents the tokenized information of a course.
@@ -141,7 +141,8 @@ pub fn parse_csv_file(
                 course_title: course_info.course_title,
                 course_full_title: course_info.course_full_title,
                 grade: {
-                    let mut grade_map = HashMap::new();
+                    // note: BTreeMap is used to maintain order of the csv columns
+                    let mut grade_map = BTreeMap::new();
                     grade_map.insert("A".to_string(), 0);
                     grade_map.insert("A-".to_string(), 0);
                     grade_map.insert("B+".to_string(), 0);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 /// This module contains functions for parsing CSV files containing course information.
@@ -30,6 +30,10 @@ use std::io::Write;
 
 const CSV_HEADER: &str = "Semester\tSection\tDepartment\tDepartment Code\tCourse Number\tCourse Title\tCourse Full Title\tA\tA-\tB+\tB\tB-\tC+\tC\tC-\tD+\tD\tD-\tF\tOther";
 
+const GRADE_NAMES: [&str; 13] = [
+    "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "D-", "F", "Other",
+];
+
 /// Represents the information of a course.
 #[derive(Serialize, Deserialize, Debug)]
 struct CourseInfo {
@@ -40,7 +44,7 @@ struct CourseInfo {
     course_number: String,
     course_title: String,
     course_full_title: String,
-    grade: BTreeMap<String, u16>,
+    grade: HashMap<String, u16>,
 }
 
 /// Represents the tokenized information of a course.
@@ -141,8 +145,7 @@ pub fn parse_csv_file(
                 course_title: course_info.course_title,
                 course_full_title: course_info.course_full_title,
                 grade: {
-                    // note: BTreeMap is used to maintain order of the csv columns
-                    let mut grade_map = BTreeMap::new();
+                    let mut grade_map = HashMap::new();
                     grade_map.insert("A".to_string(), 0);
                     grade_map.insert("A-".to_string(), 0);
                     grade_map.insert("B+".to_string(), 0);
@@ -194,7 +197,8 @@ pub fn parse_csv_file(
             course_info.course_full_title
         );
 
-        for (_, grade_count) in course_info.grade.iter() {
+        for grade_name in GRADE_NAMES.iter() {
+            let grade_count = course_info.grade.get(*grade_name).unwrap();
             output_line.push_str(&format!("\t{}", grade_count));
         }
 


### PR DESCRIPTION
As mentioned in #5, currently parsing the csv files results in non-deterministic ordering in grade columns.

By sorting the data across multiple runs of `ut_grade_parser parse`, it's clear that all the data is always there, however, the column order is randomized.

<img width="706" alt="image" src="https://github.com/doprz/UT_Grade_Parser/assets/29130894/b29c0914-9179-45a1-876e-2c917c991c38">

The random column ordering only seems to happen on the grade columns (A, A-, B+, B, B-, ..., D+, D, D-, F, Other)

The reason for this was that inserting the grade columns was just a loop over a HashMap, relying on it for the ordering. The problem with that is that [HashMaps have arbitrary ordering](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.iter:~:text=An%20iterator%20visiting%20all%20key%2Dvalue%20pairs%20in%20arbitrary%20order.). Switching to a BTreeSet wouldn't help here, since that sorts based on UTF-8 ordering, not insertion order.

fixes #5, unblocks Longhorn-Developers/UT-Registration-Plus#163
